### PR TITLE
Fixes for building using openonload-201502

### DIFF
--- a/src/include/etherfabric/doxygen/030_apps.dox
+++ b/src/include/etherfabric/doxygen/030_apps.dox
@@ -180,9 +180,10 @@ following procedure:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.sh}
 [root@server01 Onload-201109]# cd scripts/
 [root@server01 scripts]# export PATH="$PWD:$PATH"
-[root@server01 scripts]# cd ../build/_gnu_x86_64/tests/ef_vi/
+[root@server01 scripts]# mmakebuildtree        And select for example gnu_x86_64
+[root@server01 scripts]# cd ../build/gnu_x86_64/tests/ef_vi/
 [root@server01 ef_vi]# make clean
-[root@serverr01 ef_vi]# make
+[root@serverr01 ef_vi]# make ONLOAD_ONLY=1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 */


### PR DESCRIPTION
The tarball does not come with the build tree in place so it is necessary to call mmakebuildtree. Note also the strip of the '_' from the documented build path.

rbmw_parse.c is not available so we need to build with ONLOAD_ONLY set in the build environment.