### PR TITLE
Fix bash empty string test condition in onload script

### DIFF
--- a/scripts/onload
+++ b/scripts/onload
@@ -289,7 +289,7 @@ onload_set() {
   # This is used by config scripts and profile scripts.  Sets an
   # environment variable (a) if not already set, or (b) if --force-profiles
   # option is enabled.
-  if [ "$2" == "" ]; then
+  if [ -z "$2" ]; then
     # it's not in onload_set x y form - try onload_set x=y
     VAR=$(echo "$1" | cut -f1 -d=)
     VAL=$(echo "$1" | cut -f2 -d=)


### PR DESCRIPTION
We have problems with new 201502 version with custom profiles:

root@server:~# onload --profile=latency  ping ya.ru
/usr/bin/onload: 292: [: 100000: unexpected operator
/usr/bin/onload: 292: [: 0: unexpected operator
/usr/bin/onload: 292: [: 0: unexpected operator
oo:ping[23184]: Using OpenOnload 201502 Copyright 2006-2015 Solarflare Communications, 2002-2005 Level 5 Networks [0]
ping: unknown host ya.ru

The problem is new is_empty condition in onload script.
